### PR TITLE
feature(WEB-1128): adds support for base64 encoding of STORYBLOK_ORIGIN_TOKENS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ OKTA_ISSUER=changeme
 OKTA_CLIENTID=changeme
 STORYBLOK_HOST=https://api.storyblok.com/v2
 STORYBLOK_ORIGIN_TOKENS='[{"token":"changeme","regex":"^.+localhost:3000.*$"}]'
+STORYBLOK_CACHE_TTL=changeme
 SENTRY_DSN=changeme
 ENVIRONMENT=development
 VERSION=0.0.0

--- a/README.md
+++ b/README.md
@@ -31,8 +31,11 @@ See the file .env.example for all the environment variables that need to be set 
 
 The env `STORYBLOK_HOST` needs the default api host `https://api.storyblok.com/v2`.
 
-The env `STORYBLOK_ORIGIN_TOKENS` is a JSON encoded string `'[{"token":"changeme","regex":"^.+localhost:3000.*$"}]'` . It is
-an array of objects with keys token (The StoryBlok API key) and regex pattern.
+The env `STORYBLOK_ORIGIN_TOKENS` is a base64 encoded JSON string `'[{"token":"changeme","regex":"^.+localhost:3000.*$"}]'` . It is an array of objects with keys token (The StoryBlok API key) and regex pattern. It needs to be base64 encoded. The regex pattern is used to match the Origin header of the request.
 
-> The regex pattern matches with the Origin header on all requests. Make sure your regexes are specific enough as not 
+```sh
+echo '[{"token":"changeme","regex":"^.+localhost:3000.*$"}]' | base64
+```
+
+> The regex pattern matches with the Origin header on all requests. Make sure your regexes are specific enough as not
 > to match with multiple tokens.

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -142,7 +142,7 @@ export function getFilledMiniflareBindings() {
   const bindings = getMiniflareBindings();
   bindings.STORYBLOK_HOST = 'http://localhost';
   bindings.STORYBLOK_ORIGIN_TOKENS =
-    '[{"token":"1234","regex":"^.+localhost:3000.*$"}]';
+    'W3sidG9rZW4iOiIxMjM0IiwicmVnZXgiOiJeLitsb2NhbGhvc3Q6MzAwMC4qJCJ9XQo=';
 
   return bindings as Bindings;
 }

--- a/src/options.spec.ts
+++ b/src/options.spec.ts
@@ -8,7 +8,7 @@ describe('Should handle OPTIONS request', () => {
     OKTA_CLIENTID: 'someId',
     STORYBLOK_HOST: 'https://api.storyblok.com',
     STORYBLOK_ORIGIN_TOKENS:
-      '[{"token":"1234","regex":"^.+localhost:3000.*$"}]',
+      'W3sidG9rZW4iOiIxMjM0IiwicmVnZXgiOiJeLitsb2NhbGhvc3Q6MzAwMC4qJCJ9XQo=',
     SENTRY_DSN: 'https://sentry.io',
     ENVIRONMENT: 'development',
     VERSION: 'v0.0.0',

--- a/src/options.ts
+++ b/src/options.ts
@@ -52,9 +52,8 @@ export function getTokenFromOrigin(
   bindings: Bindings,
 ): string | Error {
   try {
-    const tokenMap: OriginToken[] = JSON.parse(
-      bindings.STORYBLOK_ORIGIN_TOKENS,
-    );
+    const decodedOriginTokens = parseBase64(bindings.STORYBLOK_ORIGIN_TOKENS);
+    const tokenMap: OriginToken[] = JSON.parse(decodedOriginTokens);
     const tokens = tokenMap.filter((item) => origin.match(item.regex));
     if (tokens[0]) {
       return tokens[0].token;
@@ -69,5 +68,22 @@ export function getTokenFromOrigin(
     throw new Error(
       `Incorrect configuration in STORYBLOK_ORIGIN_TOKENS error: ${err.message}`,
     );
+  }
+}
+
+/**
+ * Parses a base64 encoded string.
+ * @param {string} str - base64 encoded string
+ * @returns {string} - decoded string
+ * @throws {Error} - if the string is not valid base64
+ */
+function parseBase64(str: string) {
+  if (typeof str !== 'string' || str.trim() === '') {
+    throw new Error(`Input must be a non-empty string.`);
+  }
+  try {
+    return atob(str);
+  } catch (e) {
+    throw new Error(`Failed to decode base64 string: ${str}`);
   }
 }


### PR DESCRIPTION
## Note to reviewer
This change introduces handling of base64 encoded values for environment secret `STORYBLOK_ORIGIN_TOKENS` for a more [reliable implementation with Terxr](https://terxr-io.pondigital.solutions/docs/terxr_cli/user_guide/add#adding-service-environment-variable-with-long-length-value-such-as-sv-keys-or-github-tokens)

See ticket for more information

## Related ticket
[WEB-1128](https://pondevelopment.atlassian.net/browse/WEB-1128)